### PR TITLE
properly parse non-default flags

### DIFF
--- a/entries.go
+++ b/entries.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 )
 
 // Entries represents the object being returned from the API request /entries
@@ -32,10 +33,10 @@ type Link struct {
 func GetEntries(archive int, starred int, sort string, order string, page int, perPage int, tags string) Entries {
 	entriesURL := Config.WallabagURL + "/api/entries.json?"
 	if archive == 0 || archive == 1 {
-		entriesURL += "archive=" + string(archive) + "&"
+		entriesURL += "archive=" + strconv.Itoa(archive) + "&"
 	}
 	if starred == 0 || starred == 1 {
-		entriesURL += "starred=" + string(starred) + "&"
+		entriesURL += "starred=" + strconv.Itoa(starred) + "&"
 	}
 	if sort == "created" || sort == "updated" {
 		entriesURL += "sort=" + sort + "&"
@@ -44,10 +45,10 @@ func GetEntries(archive int, starred int, sort string, order string, page int, p
 		entriesURL += "order=" + order + "&"
 	}
 	if page > 0 {
-		entriesURL += "page=" + string(page) + "&"
+		entriesURL += "page=" + strconv.Itoa(page) + "&"
 	}
 	if perPage > 0 {
-		entriesURL += "perPage=" + string(perPage) + "&"
+		entriesURL += "perPage=" + strconv.Itoa(perPage) + "&"
 	}
 	if tags != "" {
 		entriesURL += "tags=" + tags + "&"


### PR DESCRIPTION
the string() cast was discarding zero values. the proper way to convert integers to strings is with strconv

without this, i cannot get the list of "unread" entries. i actually get:

```
$ go run config.go main.go
2017/01/29 23:10:11 getConfig: file is config.json
2017/01/29 23:10:11 main: setting wallabago.Config var
getEntries: json unmarshal failed: invalid character '<' looking for beginning of value
2017/01/29 23:10:11 unread%!(EXTRA int=0)
```

with the patch, i can successfully access unread entries.