### PR TITLE
parse more fields from the entries API

### DIFF
--- a/entries.go
+++ b/entries.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 )
 
 // Entries represents the object being returned from the API request /entries
@@ -32,10 +33,10 @@ type Link struct {
 func GetEntries(archive int, starred int, sort string, order string, page int, perPage int, tags string) Entries {
 	entriesURL := Config.WallabagURL + "/api/entries.json?"
 	if archive == 0 || archive == 1 {
-		entriesURL += "archive=" + string(archive) + "&"
+		entriesURL += "archive=" + strconv.Itoa(archive) + "&"
 	}
 	if starred == 0 || starred == 1 {
-		entriesURL += "starred=" + string(starred) + "&"
+		entriesURL += "starred=" + strconv.Itoa(starred) + "&"
 	}
 	if sort == "created" || sort == "updated" {
 		entriesURL += "sort=" + sort + "&"
@@ -44,10 +45,10 @@ func GetEntries(archive int, starred int, sort string, order string, page int, p
 		entriesURL += "order=" + order + "&"
 	}
 	if page > 0 {
-		entriesURL += "page=" + string(page) + "&"
+		entriesURL += "page=" + strconv.Itoa(page) + "&"
 	}
 	if perPage > 0 {
-		entriesURL += "perPage=" + string(perPage) + "&"
+		entriesURL += "perPage=" + strconv.Itoa(perPage) + "&"
 	}
 	if tags != "" {
 		entriesURL += "tags=" + tags + "&"

--- a/entries.go
+++ b/entries.go
@@ -19,12 +19,14 @@ type Entries struct {
 	Embedded  Embedded `json:"_embedded"`
 }
 
+// Embedded items in the API request
 type Embedded struct {
 	Items []Item `json:"items"`
 }
 
+// Item represents individual items in API responses
 type Item struct {
-	_links      Links         `json:"_links"`
+	Links       Links         `json:"_links"`
 	Annotations []interface{} `json:"annotations"`
 	CreatedAt   WallabagTime  `json:"created_at"`
 	DomainName  string        `json:"domain_name"`
@@ -40,13 +42,16 @@ type Item struct {
 	UserName    string        `json:"user_name"`
 }
 
-// should be the same as RFC3339, but that actually can't parse -XXXX offsets (without colons)
+// WallabagTimeLayout is a variation of RFC3339 but without colons in
+// the timezone delimeter, breaking the RFC
 const WallabagTimeLayout = "2006-01-02T15:04:05-0700"
 
+// WallabagTime overrides builtin time to allow for custom time parsing
 type WallabagTime struct {
 	time.Time
 }
 
+// UnmarshalJSON parses the custom date format wallabag returns
 func (t *WallabagTime) UnmarshalJSON(buf []byte) (err error) {
 	s := strings.Trim(string(buf), `"`)
 	t.Time, err = time.Parse(WallabagTimeLayout, s)

--- a/entries.go
+++ b/entries.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // Entries represents the object being returned from the API request /entries
@@ -13,7 +15,46 @@ type Entries struct {
 	Limit     int
 	Pages     int
 	Total     int
-	NaviLinks *Links `json:"_links"`
+	NaviLinks Links    `json:"_links"`
+	Embedded  Embedded `json:"_embedded"`
+}
+
+type Embedded struct {
+	Items []Item `json:"items"`
+}
+
+type Item struct {
+	_links      Links         `json:"_links"`
+	Annotations []interface{} `json:"annotations"`
+	CreatedAt   WallabagTime  `json:"created_at"`
+	DomainName  string        `json:"domain_name"`
+	ID          int           `json:"id"`
+	IsArchived  int           `json:"is_archived"`
+	IsStarred   int           `json:"is_starred"`
+	Mimetype    string        `json:"mimetype"`
+	ReadingTime int           `json:"reading_time"`
+	Tags        []interface{} `json:"tags"`
+	UpdatedAt   WallabagTime  `json:"updated_at"`
+	UserEmail   string        `json:"user_email"`
+	UserID      int           `json:"user_id"`
+	UserName    string        `json:"user_name"`
+}
+
+// should be the same as RFC3339, but that actually can't parse -XXXX offsets (without colons)
+const WallabagTimeLayout = "2006-01-02T15:04:05-0700"
+
+type WallabagTime struct {
+	time.Time
+}
+
+func (t *WallabagTime) UnmarshalJSON(buf []byte) (err error) {
+	s := strings.Trim(string(buf), `"`)
+	t.Time, err = time.Parse(WallabagTimeLayout, s)
+	if err != nil {
+		t.Time = time.Time{}
+		return
+	}
+	return
 }
 
 // Links contains four links (self, first, last, next), being part of the Entries object


### PR DESCRIPTION
i needed the list of entries which is available only in the _embedded
field. while i'm here, just find all fields already. this will grow
the memory usage but should be negligible because we read the whole
output in memory already anyways.

i believe the proper optimization would be to stream entries through a
channel, but the JSON data structure doesn't lend itself to streaming
very well.

this PR builds on top of #1.