### PR TITLE
move config file  handling from -stats to here

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,34 @@
+package wallabago
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+// Config containg all data to access wallabag API
+var Config WallabagConfig
+
+// WallabagConfig contains all data needed to connect to wallabag API like URL, id and secret of the API client and user name and according password
+type WallabagConfig struct {
+	WallabagURL  string
+	ClientID     string
+	ClientSecret string
+	UserName     string
+	UserPassword string
+}
+
+func ReadConfig(configPath string) (err error) {
+	Config, err = getConfig(configPath)
+}
+
+func getConfig(configPath string) (config wallabago.WallabagConfig, err error) {
+	raw, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return config, err
+	}
+	config, err = readJSON(raw)
+}
+
+func readJSON(raw []byte) (config wallabago.WallabagConfig, err error) {
+	err = json.Unmarshal(raw, &config)
+}

--- a/config.go
+++ b/config.go
@@ -17,18 +17,26 @@ type WallabagConfig struct {
 	UserPassword string
 }
 
-func ReadConfig(configPath string) (err error) {
-	Config, err = getConfig(configPath)
+// ReadConfig will read the configuration from the given configJSON
+// file and set the global Config setting with the results of the
+// parsing
+func ReadConfig(configJSON string) (err error) {
+	Config, err = getConfig(configJSON)
+	return
 }
 
-func getConfig(configPath string) (config wallabago.WallabagConfig, err error) {
-	raw, err := ioutil.ReadFile(configPath)
+// getConfig reads a given configJSON file and parses the result, returning a parsed config object
+func getConfig(configJSON string) (config WallabagConfig, err error) {
+	raw, err := ioutil.ReadFile(configJSON)
 	if err != nil {
-		return config, err
+		return
 	}
 	config, err = readJSON(raw)
+	return
 }
 
-func readJSON(raw []byte) (config wallabago.WallabagConfig, err error) {
+// readJSON parses a byte stream into a WallabagConfig object
+func readJSON(raw []byte) (config WallabagConfig, err error) {
 	err = json.Unmarshal(raw, &config)
+	return
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,41 @@
+package wallabago
+
+import "testing"
+
+func TestReadJson(t *testing.T) {
+	var tests = []struct {
+		input                string
+		expectedWallabagURL  string
+		expectedClientID     string
+		expectedClientSecret string
+		expectedUserName     string
+		expectedUserPassword string
+		expectedIsErrNil     bool
+	}{
+		{"{\"WallabagURL\": \"http://localhost\", \"ClientId\": \"555_puf29hbu4bnu2\", \"ClientSecret\": \"f2o9uhf32j8fj23fji2huo\", \"UserName\": \"john\", \"UserPassword\": \"passworddd\"}", "http://localhost", "555_puf29hbu4bnu2", "f2o9uhf32j8fj23fji2huo", "john", "passworddd", true},
+		{"", "", "", "", "", "", false},
+	}
+	for _, test := range tests {
+		var raw = []byte(test.input)
+		c, e := readJSON(raw)
+		if c.WallabagURL != test.expectedWallabagURL {
+			t.Errorf("readJson(%v): expectedWallabagURL %v, got %v", test.input, test.expectedWallabagURL, c.WallabagURL)
+		}
+		if c.ClientID != test.expectedClientID {
+			t.Errorf("readJson(%v): expectedClientId %v, got %v", test.input, test.expectedClientID, c.ClientID)
+		}
+		if c.ClientSecret != test.expectedClientSecret {
+			t.Errorf("readJson(%v): expectedClientSecret %v, got %v", test.input, test.expectedClientSecret, c.ClientSecret)
+		}
+		if c.UserName != test.expectedUserName {
+			t.Errorf("readJson(%v): expectedUserName %v, got %v", test.input, test.expectedUserName, c.UserName)
+		}
+		if c.UserPassword != test.expectedUserPassword {
+			t.Errorf("readJson(%v): expectedUserPassword %v, got %v", test.input, test.expectedUserPassword, c.UserPassword)
+		}
+		isErrNil := (e == nil)
+		if isErrNil != test.expectedIsErrNil {
+			t.Errorf("readJson(%v): expectedIsErrNil %v, got %v", test.input, test.expectedIsErrNil, isErrNil)
+		}
+	}
+}

--- a/token.go
+++ b/token.go
@@ -9,18 +9,7 @@ import (
 	"os"
 )
 
-// Config containg all data to access wallabag API
-var Config WallabagConfig
 var token Token
-
-// WallabagConfig contains all data needed to connect to wallabag API like URL, id and secret of the API client and user name and according password
-type WallabagConfig struct {
-	WallabagURL  string
-	ClientID     string
-	ClientSecret string
-	UserName     string
-	UserPassword string
-}
 
 // Token represents the object being returned from the oauth process at the API containing the access token, expire time, type of token, scope and a refresh token
 type Token struct {


### PR DESCRIPTION
this is a followup to https://github.com/Strubbl/wallabag-stats/issues/1 - the first part is obviously to add the necessary code to wallabago.

i moved the code to a separate `config.go` file and also included bits that were previously in `token.go` because it feels it makes more sense there.

this will obviously break wallabag-stats, but i will followup with a PR there soon.

in my app, the API change is minimal, i just had to do this:

```diff
                log.Printf("completed in %.2fs\n", time.Since(start).Seconds())
        }()
        flag.Parse()
-       config, err := getConfig()
+       err := wallabago.ReadConfig(*configJSON)
        if err != nil {
                log.Fatal(err.Error())
        }
-       wallabago.Config = config
```

looks better too!