### PR TITLE
strip unicode BOM characters from config

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package wallabago
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 )
@@ -37,6 +38,8 @@ func getConfig(configJSON string) (config WallabagConfig, err error) {
 
 // readJSON parses a byte stream into a WallabagConfig object
 func readJSON(raw []byte) (config WallabagConfig, err error) {
+	// trim BOM bytes that make the JSON parser crash
+	raw = bytes.TrimPrefix(raw, []byte("\xef\xbb\xbf"))
 	err = json.Unmarshal(raw, &config)
 	return
 }


### PR DESCRIPTION
i encountered such a situation when field-testing wallabako: the user
would copy the config snippet from the website, paste it into her
prefered text editor (LibreOffice) and save it as a .txt
file. LibreOffice then inserts a BOM character at the beginning of the
file even though that is forbidden by the JSON spec.

then the JSON parser crashes with this weird error:

    invalid character 'ï' looking for beginning of value

which makes the file unparseable. there is little the user can do to
recover: the unicode magic character is completely invisible and most
editors (vim, emacs) don't remove it. i had to copy-paste in a
terminal (because in the editor the character is kept on copy-paste
too) to actually remote the nasty stuff.

so play it safe and just cleanup config files we find. this doesn't
hurt performance and is weird, but golang people [refuse to fix this][12254].

 [12254]: https://github.com/golang/go/issues/12254