### PR TITLE
Refresh token when it expires

### DIFF
--- a/token.go
+++ b/token.go
@@ -3,65 +3,152 @@ package wallabago
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
-var token Token
+var token *Token
 
-// Token represents the object being returned from the oauth process at the API containing the access token, expire time, type of token, scope and a refresh token
+func setToken(newToken *Token) {
+	token = newToken
+}
+
+// Token represents the object being returned from the oauth process at the API
+// containing the access token, expire time (after converting it from the
+// number of seconds the token is valid to the point in time where it will
+// expires), type of token, scope and a refresh token
 type Token struct {
+	AccessToken    string
+	ExpirationTime time.Time
+	TokenType      string
+	Scope          string
+	RefreshToken   string
+}
+
+type tokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	ExpiresIn    int    `json:"expires_in"`
 	TokenType    string `json:"token_type"`
-	Scope        string
+	Scope        string `json:"scope"`
 	RefreshToken string `json:"refresh_token"`
+}
+
+// parseTokenResponse consumes a stream (typically a http.Response.Body) that
+// is expected to contain JSON that unmarshals into a tokenResponse struct
+func parseTokenResponse(reader io.ReadCloser) (*tokenResponse, error) {
+	defer reader.Close()
+
+	var tokenResponse tokenResponse
+	err := json.NewDecoder(reader).Decode(&tokenResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenResponse, nil
+}
+
+// responseToToken converts a tokenResponse into a Token, computing the point
+// in time where the token will expire using the ExpiresIn field in
+// tokenResponse and the moment in which the function is called
+func responseToToken(tokenResponse *tokenResponse) *Token {
+	expiresIn := time.Duration(tokenResponse.ExpiresIn) * time.Second
+	expirationTime := time.Now().Add(expiresIn)
+
+	return &Token{
+		AccessToken:    tokenResponse.AccessToken,
+		ExpirationTime: expirationTime,
+		TokenType:      tokenResponse.TokenType,
+		Scope:          tokenResponse.Scope,
+		RefreshToken:   tokenResponse.RefreshToken,
+	}
 }
 
 // getToken will use the credentials set in the configuration to
 // request an access token from the wallabag API
-func getToken() (Token, error) {
-	var token Token
+func getToken() (*tokenResponse, error) {
 	tokenURL := Config.WallabagURL + "/oauth/v2/token"
 	resp, err := http.PostForm(tokenURL,
-		url.Values{"grant_type": {"password"},
+		url.Values{
+			"grant_type":    {"password"},
 			"client_id":     {Config.ClientID},
 			"client_secret": {Config.ClientSecret},
 			"username":      {Config.UserName},
 			"password":      {Config.UserPassword},
 		})
 	if err != nil {
-		return token, err
+		return nil, err
 	}
-	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
-		return token, fmt.Errorf("getToken: bad response from server: %v", resp.StatusCode)
+		return nil, fmt.Errorf(
+			"getToken: bad response from server: %v", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+
+	return parseTokenResponse(resp.Body)
+}
+
+// refreshToken will use the credentials set in the configuration to
+// refresh the token stored in a previous request. It errors if there is no
+// token stored or if the refresh request fails
+func refreshToken() (*tokenResponse, error) {
+	if token == nil {
+		return nil, fmt.Errorf("A nil token cannot be refreshed")
+	}
+
+	tokenURL := Config.WallabagURL + "/oauth/v2/token"
+	resp, err := http.PostForm(tokenURL,
+		url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {Config.ClientID},
+			"client_secret": {Config.ClientSecret},
+			"refresh_token": {token.RefreshToken},
+		})
 	if err != nil {
-		return token, err
+		return nil, err
 	}
-	//log.Printf("GetToken: body=%v\n", string(body))
-	err = json.Unmarshal(body, &token)
-	return token, err
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"refreshToken: bad response from server: %v", resp.StatusCode)
+	}
+
+	return parseTokenResponse(resp.Body)
 }
 
 func checkForToken() error {
-	var err error
-	if token.TokenType == "" || token.AccessToken == "" {
-		token, err = getToken()
+	if token == nil {
+		tokenResponse, err := getToken()
+		if err != nil {
+			return err
+		}
+
+		setToken(responseToToken(tokenResponse))
+		return nil
 	}
-	return err
+
+	if token.ExpirationTime.Before(time.Now()) {
+		tokenResponse, err := refreshToken()
+		if err != nil {
+			return err
+		}
+
+		setToken(responseToToken(tokenResponse))
+		return err
+	}
+
+	return nil
 }
 
 // GetAuthTokenHeader will make sure there's a working token and
 // return a valid string to be used as an Authentication: header
-func GetAuthTokenHeader() string {
-	checkForToken()
-	if token.TokenType == "" || token.AccessToken == "" {
-		return ""
+func GetAuthTokenHeader() (string, error) {
+	err := checkForToken()
+	if err != nil {
+		return "", err
 	}
-	return strings.ToUpper(string(token.TokenType[0])) + token.TokenType[1:len(token.TokenType)] + " " + token.AccessToken
+
+	return strings.Title(token.TokenType) + " " + token.AccessToken, nil
 }

--- a/token.go
+++ b/token.go
@@ -39,8 +39,6 @@ type tokenResponse struct {
 // parseTokenResponse consumes a stream (typically a http.Response.Body) that
 // is expected to contain JSON that unmarshals into a tokenResponse struct
 func parseTokenResponse(reader io.ReadCloser) (*tokenResponse, error) {
-	defer reader.Close()
-
 	var tokenResponse tokenResponse
 	err := json.NewDecoder(reader).Decode(&tokenResponse)
 	if err != nil {
@@ -87,6 +85,7 @@ func getToken() (*tokenResponse, error) {
 			"getToken: bad response from server: %v", resp.StatusCode)
 	}
 
+	defer resp.Body.Close()
 	return parseTokenResponse(resp.Body)
 }
 
@@ -115,6 +114,7 @@ func refreshToken() (*tokenResponse, error) {
 			"refreshToken: bad response from server: %v", resp.StatusCode)
 	}
 
+	defer resp.Body.Close()
 	return parseTokenResponse(resp.Body)
 }
 

--- a/token_test.go
+++ b/token_test.go
@@ -23,8 +23,38 @@ func TestGetToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, but got %v", err)
 	}
-	expectedToken := Token{"294hf92ufurjfgoiqjfioj4", 3600, "bearer", "null", "ZGE5MDg3ZTNjNmNkYTY0ZWZh"}
-	if token != expectedToken {
+	expectedToken := tokenResponse{"294hf92ufurjfgoiqjfioj4", 3600, "bearer", "null", "ZGE5MDg3ZTNjNmNkYTY0ZWZh"}
+	if *token != expectedToken {
+		t.Errorf("TestGetToken(): expected %v, got %v", expectedToken, token)
+	}
+}
+
+func TestRefreshToken(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	wbgcfg := NewWallabagConfig(server.URL, "asdf", "ghkj", "wallabago", "555nase")
+	SetConfig(wbgcfg)
+	mux.HandleFunc("/oauth/v2/token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"access_token":"294hf92ufurjfgoiqjfioj4","refresh_token": "ZGE5MDg3ZTNjNmNkYTY0ZWZh","expires_in":3600,"scope": "null", "token_type": "bearer"}`)
+	})
+
+	// Set the token first so we can refresh it later
+	token, err := getToken()
+	setToken(responseToToken(token))
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
+
+	refreshedToken, err := refreshToken()
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
+
+	expectedToken := tokenResponse{"294hf92ufurjfgoiqjfioj4", 3600, "bearer", "null", "ZGE5MDg3ZTNjNmNkYTY0ZWZh"}
+	if *refreshedToken != expectedToken {
 		t.Errorf("TestGetToken(): expected %v, got %v", expectedToken, token)
 	}
 }
@@ -41,7 +71,10 @@ func TestGetAuthTokenHeader(t *testing.T) {
 		fmt.Fprintln(w, `{"access_token":"294hf92ufurjfgoiqjfioj4","refresh_token": "ZGE5MDg3ZTNjNmNkYTY0ZWZh","expires_in":3600,"scope": "null", "token_type": "bearer"}`)
 	})
 
-	authTokenHeader := GetAuthTokenHeader()
+	authTokenHeader, err := GetAuthTokenHeader()
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
 	expectedAuthTokenHeader := "Bearer 294hf92ufurjfgoiqjfioj4"
 	if authTokenHeader != expectedAuthTokenHeader {
 		t.Errorf("TestGetAuthTokenHeader(): expected %v, got %v", expectedAuthTokenHeader, authTokenHeader)

--- a/utils.go
+++ b/utils.go
@@ -40,7 +40,11 @@ func APICall(apiURL string, httpMethod string, postData []byte) ([]byte, error) 
 		return nil, err
 	}
 	// auth
-	authString := GetAuthTokenHeader()
+	authString, err := GetAuthTokenHeader()
+	if err != nil {
+		return nil, err
+	}
+
 	req.Header.Add("Authorization", authString)
 	req.Header.Add("Content-Type", "application/json")
 	// exec API request

--- a/utils.go
+++ b/utils.go
@@ -42,6 +42,7 @@ func APICall(apiURL string, httpMethod string, postData []byte) ([]byte, error) 
 	// auth
 	authString := GetAuthTokenHeader()
 	req.Header.Add("Authorization", authString)
+	req.Header.Add("Content-Type", "application/json")
 	// exec API request
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
I am running a Telegram bot that uses wallabago to contact Wallabag API. The bot is running for far more than an hour (the time in which the token usually expires), and when that time passes all requests to the API fail.

This PR fixes that by refreshing the token when its expiration time comes. It also adds the `Content-Type: application/json` header to APICall.